### PR TITLE
Fix typo in Bricks example.vm

### DIFF
--- a/Bricks/example.vm
+++ b/Bricks/example.vm
@@ -1,4 +1,4 @@
-#set ( $sib = $_XPathTool.selectSingleNode($contentRoot, "/system-index-block) )
+#set ( $sib = $_XPathTool.selectSingleNode($contentRoot, "/system-index-block") )
 
 #set ( $bricks = $_XPathTool.selectNodes($sib, "system-page/system-data-structure/brick") )
 #macro ( useBricks $contentString )


### PR DESCRIPTION
A client (Bill White) pointed out a missing end quote that makes the example.vm format included in the Bricks site unsaveable in Cascade.